### PR TITLE
Minor robustness fixes for path resolution and FSL module loading

### DIFF
--- a/modwrap.sh
+++ b/modwrap.sh
@@ -7,8 +7,8 @@ postcmd=$2
 shift
 shift
 
-$prepcmd
+$prepcmd || true
 
 "$@"
 
-$postcmd
+$postcmd || true

--- a/runscript/anat_from_bids.py
+++ b/runscript/anat_from_bids.py
@@ -24,7 +24,7 @@ def main():
         help='Working directory')
     args = parser.parse_args()
     
-    args.input = os.path.expanduser(args.input)
+    args.input = os.path.realpath(os.path.expanduser(args.input))
     args.raw_output = os.path.expanduser(args.raw_output)
 
     raw_basename = os.path.basename(args.raw_output)

--- a/runscript/calculate_nuisance_params.sh
+++ b/runscript/calculate_nuisance_params.sh
@@ -22,19 +22,16 @@ CODE_DIR=${16}
 
 tmpdir=$(mktemp --directory --tmpdir=${OUTDIR})
 
-if [ "${IPROC_SRUN:-NO}" == "YES" ] ; then
-    #we're running in a srun-safe environment
-srun --export=ALL -n 1 -c $SLURM_CPUS_PER_TASK parallel -j 3 --tmpdir=${tmpdir} <<EOF
+if command -v parallel &>/dev/null; then
+    parallel -j 3 --tmpdir=${tmpdir} <<EOF
 fslmeants -i ${RESID_IN} -o ${CSF_TS} -m ${CSF_MASK}
 fslmeants -i ${RESID_IN} -o ${WM_TS} -m ${WM_MASK}
 fslmeants -i ${RESID_IN} -o ${WB_TS} -m ${WB_MASK}
 EOF
 else
-parallel -j 3 --tmpdir=${tmpdir} <<EOF
-fslmeants -i ${RESID_IN} -o ${CSF_TS} -m ${CSF_MASK}
-fslmeants -i ${RESID_IN} -o ${WM_TS} -m ${WM_MASK}
-fslmeants -i ${RESID_IN} -o ${WB_TS} -m ${WB_MASK}
-EOF
+    fslmeants -i ${RESID_IN} -o ${CSF_TS} -m ${CSF_MASK}
+    fslmeants -i ${RESID_IN} -o ${WM_TS} -m ${WM_MASK}
+    fslmeants -i ${RESID_IN} -o ${WB_TS} -m ${WB_MASK}
 fi
 # note: this WB_TS is identical in all respects to the one produced
 #by runscript/remove_WB_only.sh

--- a/runscript/fmap_from_bids_topup.sh
+++ b/runscript/fmap_from_bids_topup.sh
@@ -16,6 +16,9 @@ MASK_COPY=$8 # added by LMD
 preptool=topup
 
 # symlink BIDS NIFTI files to the expected locations ${FDIR}/AP_img.nii.gz and ${FDIR}/PA_img.nii.gz
+# resolve to absolute paths so symlinks remain valid after cd into FDIR
+AP_BIDS_NIFTI=$(realpath "${AP_BIDS_NIFTI}")
+PA_BIDS_NIFTI=$(realpath "${PA_BIDS_NIFTI}")
 ln -sf "${AP_BIDS_NIFTI}" "${FDIR}/AP_img.nii.gz"
 ln -sf "${PA_BIDS_NIFTI}" "${FDIR}/PA_img.nii.gz"
 

--- a/runscript/fmap_from_bids_topup.sh
+++ b/runscript/fmap_from_bids_topup.sh
@@ -16,8 +16,8 @@ MASK_COPY=$8 # added by LMD
 preptool=topup
 
 # symlink BIDS NIFTI files to the expected locations ${FDIR}/AP_img.nii.gz and ${FDIR}/PA_img.nii.gz
-ln -s "${AP_BIDS_NIFTI}" "${FDIR}/AP_img.nii.gz"
-ln -s "${PA_BIDS_NIFTI}" "${FDIR}/PA_img.nii.gz"
+ln -sf "${AP_BIDS_NIFTI}" "${FDIR}/AP_img.nii.gz"
+ln -sf "${PA_BIDS_NIFTI}" "${FDIR}/PA_img.nii.gz"
 
 # change later if it comes up
 b02b0=$codedir/configs/b02b0.cnf

--- a/runscript/fmap_topup_prep.sh
+++ b/runscript/fmap_topup_prep.sh
@@ -10,7 +10,14 @@ OUTDIR=$5
 MASK_COPY=$6 # added for FMAP QC
 
 # needed for the best version of topup
-module load fsl/6.0.1-ncf
+if module load fsl/6.0.1-ncf 2>/dev/null; then
+    echo "Loaded fsl/6.0.1-ncf via module"
+elif [ -n "${FSLDIR:-}" ]; then
+    echo "Using FSL from FSLDIR: $FSLDIR"
+else
+    echo "ERROR: FSL not available via module or FSLDIR" >&2
+    exit 1
+fi
 
 cd $FDIR
 

--- a/runscript/fs6_project_to_surf.sh
+++ b/runscript/fs6_project_to_surf.sh
@@ -24,56 +24,43 @@ if [ "${IPROC_SRUN:-NO}" == "YES" ] ; then
 else
     _IPROC_RUNNER=""
 fi
+
+BOLDS=("$BOLD" "$BOLD2" "$BOLD3" "$BOLD4")
+
+run_cmds() {
+    if command -v parallel &>/dev/null; then
+        $_IPROC_RUNNER parallel -j 4 --tmpdir=${tmpdir}
+    else
+        while IFS= read -r cmd; do
+            bash -c "$cmd"
+        done
+    fi
+}
+
 #Project data
-$_IPROC_RUNNER parallel -j 4 --tmpdir=${tmpdir} <<EOF
-mri_vol2surf --mov $BOLDPATH/${BOLD}.nii.gz --regheader $SESST --hemi lh --projfrac 0.5 --trgsubject fsaverage6 --o $tmpdir/lh.${BOLD}_fsaverage6.nii --reshape --interp trilinear
-mri_vol2surf --mov $BOLDPATH/${BOLD}.nii.gz --regheader $SESST --hemi rh --projfrac 0.5 --trgsubject fsaverage6 --o $tmpdir/rh.${BOLD}_fsaverage6.nii --reshape --interp trilinear
-mri_vol2surf --mov $BOLDPATH/${BOLD2}.nii.gz --regheader $SESST --hemi lh --projfrac 0.5 --trgsubject fsaverage6 --o $tmpdir/lh.${BOLD2}_fsaverage6.nii --reshape --interp trilinear
-mri_vol2surf --mov $BOLDPATH/${BOLD2}.nii.gz --regheader $SESST --hemi rh --projfrac 0.5 --trgsubject fsaverage6 --o $tmpdir/rh.${BOLD2}_fsaverage6.nii --reshape --interp trilinear
-mri_vol2surf --mov $BOLDPATH/${BOLD3}.nii.gz --regheader $SESST --hemi lh --projfrac 0.5 --trgsubject fsaverage6 --o $tmpdir/lh.${BOLD3}_fsaverage6.nii --reshape --interp trilinear
-mri_vol2surf --mov $BOLDPATH/${BOLD3}.nii.gz --regheader $SESST --hemi rh --projfrac 0.5 --trgsubject fsaverage6 --o $tmpdir/rh.${BOLD3}_fsaverage6.nii --reshape --interp trilinear
-mri_vol2surf --mov $BOLDPATH/${BOLD4}.nii.gz --regheader $SESST --hemi lh --projfrac 0.5 --trgsubject fsaverage6 --o $tmpdir/lh.${BOLD4}_fsaverage6.nii --reshape --interp trilinear
-mri_vol2surf --mov $BOLDPATH/${BOLD4}.nii.gz --regheader $SESST --hemi rh --projfrac 0.5 --trgsubject fsaverage6 --o $tmpdir/rh.${BOLD4}_fsaverage6.nii --reshape --interp trilinear
+run_cmds <<EOF
+$(for b in "${BOLDS[@]}"; do
+    echo "mri_vol2surf --mov $BOLDPATH/${b}.nii.gz --regheader $SESST --hemi lh --projfrac 0.5 --trgsubject fsaverage6 --o $tmpdir/lh.${b}_fsaverage6.nii --reshape --interp trilinear"
+    echo "mri_vol2surf --mov $BOLDPATH/${b}.nii.gz --regheader $SESST --hemi rh --projfrac 0.5 --trgsubject fsaverage6 --o $tmpdir/rh.${b}_fsaverage6.nii --reshape --interp trilinear"
+done)
 EOF
 
 #Smooth data
-$_IPROC_RUNNER parallel -j 4 --tmpdir=${tmpdir} <<EOF
-mri_surf2surf --hemi lh --s fsaverage6 --sval $tmpdir/lh.${BOLD}_fsaverage6.nii --cortex --fwhm-trg ${SMOOTH} --tval $tmpdir/lh.${BOLD}_fsaverage6_sm${SMOOTH_NAME}.nii --reshape
-mri_surf2surf --hemi rh --s fsaverage6 --sval $tmpdir/rh.${BOLD}_fsaverage6.nii --cortex --fwhm-trg ${SMOOTH} --tval $tmpdir/rh.${BOLD}_fsaverage6_sm${SMOOTH_NAME}.nii --reshape
-mri_surf2surf --hemi lh --s fsaverage6 --sval $tmpdir/lh.${BOLD2}_fsaverage6.nii --cortex --fwhm-trg ${SMOOTH} --tval $tmpdir/lh.${BOLD2}_fsaverage6_sm${SMOOTH_NAME}.nii --reshape
-mri_surf2surf --hemi rh --s fsaverage6 --sval $tmpdir/rh.${BOLD2}_fsaverage6.nii --cortex --fwhm-trg ${SMOOTH} --tval $tmpdir/rh.${BOLD2}_fsaverage6_sm${SMOOTH_NAME}.nii --reshape
-mri_surf2surf --hemi lh --s fsaverage6 --sval $tmpdir/lh.${BOLD3}_fsaverage6.nii --cortex --fwhm-trg ${SMOOTH} --tval $tmpdir/lh.${BOLD3}_fsaverage6_sm${SMOOTH_NAME}.nii --reshape
-mri_surf2surf --hemi rh --s fsaverage6 --sval $tmpdir/rh.${BOLD3}_fsaverage6.nii --cortex --fwhm-trg ${SMOOTH} --tval $tmpdir/rh.${BOLD3}_fsaverage6_sm${SMOOTH_NAME}.nii --reshape
-mri_surf2surf --hemi lh --s fsaverage6 --sval $tmpdir/lh.${BOLD4}_fsaverage6.nii --cortex --fwhm-trg ${SMOOTH} --tval $tmpdir/lh.${BOLD4}_fsaverage6_sm${SMOOTH_NAME}.nii --reshape
-mri_surf2surf --hemi rh --s fsaverage6 --sval $tmpdir/rh.${BOLD4}_fsaverage6.nii --cortex --fwhm-trg ${SMOOTH} --tval $tmpdir/rh.${BOLD4}_fsaverage6_sm${SMOOTH_NAME}.nii --reshape
+run_cmds <<EOF
+$(for b in "${BOLDS[@]}"; do
+    echo "mri_surf2surf --hemi lh --s fsaverage6 --sval $tmpdir/lh.${b}_fsaverage6.nii --cortex --fwhm-trg ${SMOOTH} --tval $tmpdir/lh.${b}_fsaverage6_sm${SMOOTH_NAME}.nii --reshape"
+    echo "mri_surf2surf --hemi rh --s fsaverage6 --sval $tmpdir/rh.${b}_fsaverage6.nii --cortex --fwhm-trg ${SMOOTH} --tval $tmpdir/rh.${b}_fsaverage6_sm${SMOOTH_NAME}.nii --reshape"
+done)
 EOF
 
-$_IPROC_RUNNER parallel -j 4 --tmpdir=${tmpdir} <<EOF
-gzip -f $tmpdir/lh.${BOLD}_fsaverage6_sm${SMOOTH_NAME}.nii
-gzip -f $tmpdir/rh.${BOLD}_fsaverage6_sm${SMOOTH_NAME}.nii
-gzip -f $tmpdir/lh.${BOLD}_fsaverage6.nii
-gzip -f $tmpdir/rh.${BOLD}_fsaverage6.nii
-EOF
-
-$_IPROC_RUNNER parallel -j 4 --tmpdir=${tmpdir} <<EOF
-gzip -f $tmpdir/lh.${BOLD2}_fsaverage6_sm${SMOOTH_NAME}.nii
-gzip -f $tmpdir/rh.${BOLD2}_fsaverage6_sm${SMOOTH_NAME}.nii
-gzip -f $tmpdir/lh.${BOLD2}_fsaverage6.nii
-gzip -f $tmpdir/rh.${BOLD2}_fsaverage6.nii
-EOF
-
-$_IPROC_RUNNER parallel -j 4 --tmpdir=${tmpdir} <<EOF
-gzip -f $tmpdir/lh.${BOLD3}_fsaverage6_sm${SMOOTH_NAME}.nii
-gzip -f $tmpdir/rh.${BOLD3}_fsaverage6_sm${SMOOTH_NAME}.nii
-gzip -f $tmpdir/lh.${BOLD3}_fsaverage6.nii
-gzip -f $tmpdir/rh.${BOLD3}_fsaverage6.nii
-EOF
-
-$_IPROC_RUNNER parallel -j 4 --tmpdir=${tmpdir} <<EOF
-gzip -f $tmpdir/lh.${BOLD4}_fsaverage6_sm${SMOOTH_NAME}.nii
-gzip -f $tmpdir/rh.${BOLD4}_fsaverage6_sm${SMOOTH_NAME}.nii
-gzip -f $tmpdir/lh.${BOLD4}_fsaverage6.nii
-gzip -f $tmpdir/rh.${BOLD4}_fsaverage6.nii
+# Gzip outputs
+run_cmds <<EOF
+$(for b in "${BOLDS[@]}"; do
+    echo "gzip -f $tmpdir/lh.${b}_fsaverage6_sm${SMOOTH_NAME}.nii"
+    echo "gzip -f $tmpdir/rh.${b}_fsaverage6_sm${SMOOTH_NAME}.nii"
+    echo "gzip -f $tmpdir/lh.${b}_fsaverage6.nii"
+    echo "gzip -f $tmpdir/rh.${b}_fsaverage6.nii"
+done)
 EOF
 
 #rsync -av --remove-source-files ${tmpdir}/* ${OUTPATH}

--- a/runscript/func_from_bids.py
+++ b/runscript/func_from_bids.py
@@ -33,7 +33,7 @@ def main():
         help='Number of echos')
     args = parser.parse_args()
     
-    args.input = os.path.expanduser(args.input)
+    args.input = os.path.realpath(os.path.expanduser(args.input))
     args.output = os.path.expanduser(args.output)
 
     os.makedirs(args.work_dir, exist_ok=True)


### PR DESCRIPTION
These fixes were identified while running iProc in an environment that does not use a module system — FSL is manually configured via `$FSLDIR` rather than module load. 
- Tested on:
  - Rocky Linux 9
  - FSL 6.0.7.19
  - FreeSurfer 7.4.1

1. Allow manual FSL setup in fmap_topup_prep.sh: The previous code unconditionally called `module load fsl/6.0.1-ncf`, which fails on systems without environment modules. The updated logic tries the module load first, falls back to `$FSLDIR` if the module is unavailable, and exits with a clear error if neither is present.
2. Ignore module load failures in `modwrap.sh`: Changed pre/post commands to use `|| true` so non-critical module load errors no longer abort the pipeline.
3. Resolve input paths to absolute in `anat_from_bids.py` and `func_from_bids.py`: Replaced `expanduser `with `realpath(expanduser(...))` to prevent broken paths when the working directory changes mid-pipeline.
4. Fix broken symlinks in `fmap_from_bids_topup.sh`: Resolve AP/PA NIFTI paths to absolute via realpath before symlinking, and use `ln -sf `to overwrite stale links. This ensures symlinks remain valid after `cd` into `FDIR`.
5. Added robust fallback for GNU parallel to ensure scripts run when it is not installed in `calculate_nuisance_params.sh` and `fs6_project_to_surf.sh`.
6. Also reduced code duplication in `fs6_project_to_surf.sh` by converting repeated per-BOLD blocks into loop-based logic with a helper function—mainly a convenient cleanup while implementing the fallback.

